### PR TITLE
Add SoloStrike app store

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ Start your own appstore: [github.com/getumbrel/umbrel-community-app-store](https
   - * [SoloStrike](https://github.com/gbechtel-beck/umbrelsolostrike-app-store) [![stars](https://img.shields.io/github/stars/gbechtel-beck/umbrelsolostrike-app-store.svg?style=social)](https://github.com/gbechtel-beck/umbrelsolostrike-app-store)
   Self-hosted Bitcoin home-mining tools.
   + Avalon Q Controller: Schedule, monitor, and rotate pools across a fleet of Canaan Avalon Q home Bitcoin miners.
-  + CKpool Solo: Solo CKpool for solo Bitcoin mining.
-  + FleetSwarm: Fleet management dashboard for solo and pool mining setups.
+  + CKpool Solo: Host your own solo Bitcoin mining pool — keep the full block reward.
+  + FleetSwarm: Health dashboard for mixed Bitcoin ASIC fleets.
 
 - [Nebula](https://github.com/itsnebulalol/umbrel-store) ![stars](https://img.shields.io/github/stars/itsnebulalol/umbrel-store.svg?style=social)
   - Umami: Umami is an open source, privacy-focused alternative to Google Analytics.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ Start your own appstore: [github.com/getumbrel/umbrel-community-app-store](https
   Focused on encouraging useful self-hosted alternatives to proprietary software.
   - rhasspy: Rhasspy is an open source, fully offline voice assistant.
   - wired: anonymous first nostr client, using PoW to prevent spam. getwired.app
+ 
+  - * [SoloStrike](https://github.com/gbechtel-beck/umbrelsolostrike-app-store) [![stars](https://img.shields.io/github/stars/gbechtel-beck/umbrelsolostrike-app-store.svg?style=social)](https://github.com/gbechtel-beck/umbrelsolostrike-app-store)
+  Self-hosted Bitcoin home-mining tools.
+  + Avalon Q Controller: Schedule, monitor, and rotate pools across a fleet of Canaan Avalon Q home Bitcoin miners.
+  + CKpool Solo: Solo CKpool for solo Bitcoin mining.
+  + FleetSwarm: Fleet management dashboard for solo and pool mining setups.
 
 - [Nebula](https://github.com/itsnebulalol/umbrel-store) ![stars](https://img.shields.io/github/stars/itsnebulalol/umbrel-store.svg?style=social)
   - Umami: Umami is an open source, privacy-focused alternative to Google Analytics.


### PR DESCRIPTION
Adds my community app store, **SoloStrike**, focused on self-hosted Bitcoin home-mining tools for Umbrel.

https://github.com/gbechtel-beck/umbrelsolostrike-app-store

Three apps included:

- **Avalon Q Controller** — Multi-miner dashboard, scheduler, and pool rotation for Canaan Avalon Q home Bitcoin miners. No cloud, no telemetry, fully self-hosted. Source: https://github.com/gbechtel-beck/avalon-q-controller
- **CKpool Solo** — Host your own CKpool-based solo Bitcoin mining pool
- **FleetSwarm** — Health dashboard for mixed Bitcoin ASIC fleets

All three are MIT-licensed and ship as Docker images on GHCR.